### PR TITLE
Add API Functionality to Create SwearJars and to Add Swears to specific SwearJars

### DIFF
--- a/backend/pkg/database/mongodb/helper.go
+++ b/backend/pkg/database/mongodb/helper.go
@@ -1,13 +1,31 @@
 package mongodb
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 func validateRequiredFields(requiredFields []string, object map[string]interface{}) error {
 	for _, field := range requiredFields {
 		value, ok := object[field]
-		if value == "" || !ok {
+		if !ok || isEmpty(value) {
 			return fmt.Errorf("missing required field: %s", field)
 		}
 	}
 	return nil
+}
+
+func isEmpty(value interface{}) bool {
+	// Check for empty string
+	if str, ok := value.(string); ok {
+		return str == ""
+	}
+	// Check for nil slice or empty slice
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return v.Len() == 0
+	}
+	// Add more type checks if necessary
+	return false
 }

--- a/backend/pkg/http/rest/handler.go
+++ b/backend/pkg/http/rest/handler.go
@@ -166,7 +166,8 @@ func (h *Handler) CreateSwearJar(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
-		UserID primitive.ObjectID `json:"userID"`
+		UserID     primitive.ObjectID `json:"userID"`
+		SwearJarId primitive.ObjectID `json:"SwearJarId"`
 	}
 
 	var req Request
@@ -180,8 +181,8 @@ func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 		DateTime: time.Now(),
 		Active:   true,
 		UserID:   req.UserID,
+		SwearJarId: req.SwearJarId,
 	}
-
 	err = h.sjService.AddSwear(s)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -1,11 +1,13 @@
 package swearJar
 
 type Service interface {
+	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
 	// TODO: GetSwears() []Swear
 }
 
 type Repository interface {
+	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
 	// TODO: GetSwears() []Swear
 }
@@ -17,6 +19,10 @@ type service struct {
 // NewService creates an adding service with the necessary dependencies
 func NewService(r Repository) Service {
 	return &service{r}
+}
+
+func (s *service) CreateSwearJar(sj SwearJar) error {
+	return s.r.CreateSwearJar(sj)
 }
 
 func (s *service) AddSwear(swear Swear) error {

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -1,5 +1,11 @@
 package swearJar
 
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
 type Service interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
@@ -9,6 +15,7 @@ type Service interface {
 type Repository interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
+	GetSwearJarOwners(swearJarId primitive.ObjectID) (owners []primitive.ObjectID, err error) 
 	// TODO: GetSwears() []Swear
 }
 
@@ -26,5 +33,23 @@ func (s *service) CreateSwearJar(sj SwearJar) error {
 }
 
 func (s *service) AddSwear(swear Swear) error {
+	// Fetch the owners of the SwearJar
+	owners, err := s.r.GetSwearJarOwners(swear.SwearJarId)
+	if err != nil {
+		return err
+	}
+
+	// Check if UserID is an owner of the SwearJar
+	isOwner := false
+	for _, ownerID := range owners {
+		if ownerID == swear.UserID {
+			isOwner = true
+			break
+		}
+	}
+	if !isOwner {
+		return fmt.Errorf("User ID: %s is not an owner of SwearJar ID: %s", swear.UserID.Hex(), swear.SwearJarId.Hex())
+	}
+
 	return s.r.AddSwear(swear)
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -11,5 +11,5 @@ type Swear struct {
 	UserID     primitive.ObjectID `bson:"user_id"`
 	DateTime   time.Time          `bson:"swear_time"`
 	Active     bool               `bson:"active"`
-	swearJarId primitive.ObjectID `bson:"swear_jar_id"`
+	SwearJarId primitive.ObjectID `bson:"swear_jar_id"`
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -1,13 +1,15 @@
 package swearJar
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Swear struct {
-	ObjectID primitive.ObjectID `bson:"_id,omitempty"`
-	UserID   primitive.ObjectID `bson:"user_id"`
-	DateTime time.Time          `bson:"swear_time"`
-	Active   bool               `bson:"active"`
+	ObjectID   primitive.ObjectID `bson:"_id,omitempty"`
+	UserID     primitive.ObjectID `bson:"user_id"`
+	DateTime   time.Time          `bson:"swear_time"`
+	Active     bool               `bson:"active"`
+	swearJarId primitive.ObjectID `bson:"swear_jar_id"`
 }

--- a/backend/pkg/swearJar/swearJar.go
+++ b/backend/pkg/swearJar/swearJar.go
@@ -1,0 +1,10 @@
+package swearJar
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type SwearJar struct {
+	ObjectID primitive.ObjectID   `bson:"_id,omitempty"`
+	Name     string               `bson:"name"`
+	Desc     string               `bson:"desc"`
+	Owners   []primitive.ObjectID `bson:"owners"`
+}


### PR DESCRIPTION
### Description:
This pull request introduces api features that allow the creation of SwearJars and Adding of Swears to specific SwearJars.

### 1. Create SwearJar
If all userIds are valid, SwearJar will be created in db

A new endpoint /swearjar, using the POST method, expects the following payload:
```
{
    "Name": "Test SwearJar",
    "Desc": "Test SJ Description",
    "Owners": [ // list of userIds
        "66adf42cbaf88c95598b4991",
        "66adf666583eea76e31a52c6"
    ]
}
```

### 2. Add Swears
Users can add swears to a SwearJar if they are an owner of that SwearJar.

A new endpoint /swear, using the POST method, expects the following payload:
```
{
    "UserID": "66adf42cbaf88c95598b4991",
    "SwearJarId": "66af4b2bb278134f07fdac1d"
}
```
