### PR TITLE
Separate Service and Repository Layers

### DIFF
--- a/backend/pkg/authentication/service.go
+++ b/backend/pkg/authentication/service.go
@@ -27,7 +27,7 @@ type Repository interface {
 
 type Service interface {
 	SignUp(User) error
-	Login(User) (string, string, error)
+	Login(User) (jwt string, csrfToken string, err error)
 }
 
 type service struct {
@@ -47,7 +47,7 @@ func (s *service) SignUp(u User) error {
 	return s.r.SignUp(u)
 }
 
-func (s *service) Login(u User) (string, string, error) {
+func (s *service) Login(u User) (jwt string, csrfToken string, err error) {
 	storedUser, err := s.r.GetUserByEmail(u.Email)
 	if err != nil {
 		return "", "", err
@@ -66,7 +66,7 @@ func (s *service) Login(u User) (string, string, error) {
 		return "", "", err
 	}
 
-	csrfToken, err := generateCSRFToken()
+	csrfToken, err = generateCSRFToken()
 	if err != nil {
 		return "", "", err
 	}

--- a/backend/pkg/authentication/user.go
+++ b/backend/pkg/authentication/user.go
@@ -1,12 +1,7 @@
 package authentication
 
-import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
-)
-
 type User struct {
-	ObjectID primitive.ObjectID `bson:"_id,omitempty"`
-	Name     string             `bson:"name"`
-	Password string             `bson:"password"`
-	Email    string             `bson:"email"`
+	Name     string
+	Password string
+	Email    string
 }

--- a/backend/pkg/database/mongodb/helper.go
+++ b/backend/pkg/database/mongodb/helper.go
@@ -1,13 +1,31 @@
 package mongodb
 
-import "fmt"
+import (
+	"fmt"
+	"reflect"
+)
 
 func validateRequiredFields(requiredFields []string, object map[string]interface{}) error {
 	for _, field := range requiredFields {
 		value, ok := object[field]
-		if value == "" || !ok {
+		if !ok || isEmpty(value) {
 			return fmt.Errorf("missing required field: %s", field)
 		}
 	}
 	return nil
+}
+
+func isEmpty(value interface{}) bool {
+	// Check for empty string
+	if str, ok := value.(string); ok {
+		return str == ""
+	}
+	// Check for nil slice or empty slice
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Slice, reflect.Array:
+		return v.Len() == 0
+	}
+	// Add more type checks if necessary
+	return false
 }

--- a/backend/pkg/database/mongodb/repository.go
+++ b/backend/pkg/database/mongodb/repository.go
@@ -124,14 +124,14 @@ func (r *MongoRepository) GetSwearJarOwners(swearJarId string) (owners []string,
 
 func (r *MongoRepository) AddSwear(s swearJar.Swear) error {
 	userIDHex, err := primitive.ObjectIDFromHex(s.UserID)
-    if err != nil {
-        return fmt.Errorf("invalid UserID: %v", err)
-    }
+	if err != nil {
+		return fmt.Errorf("invalid UserID: %v", err)
+	}
 
-    swearJarIdHex, err := primitive.ObjectIDFromHex(s.SwearJarId)
-    if err != nil {
-        return fmt.Errorf("invalid SwearJarId: %v", err)
-    }
+	swearJarIdHex, err := primitive.ObjectIDFromHex(s.SwearJarId)
+	if err != nil {
+		return fmt.Errorf("invalid SwearJarId: %v", err)
+	}
 
 	_, err = r.swears.InsertOne(
 		context.TODO(),

--- a/backend/pkg/database/mongodb/repository.go
+++ b/backend/pkg/database/mongodb/repository.go
@@ -64,14 +64,24 @@ func (r *MongoRepository) CreateSwearJar(sj swearJar.SwearJar) error {
 		return err
 	}
 
-	// Check if all owner IDs are valid users
-	for _, ownerID := range sj.Owners {
+	// Convert []string to []primitive.ObjectID in one go
+	ownerIDs := make([]primitive.ObjectID, len(sj.Owners))
+	for i, ownerID := range sj.Owners {
+		oid, err := primitive.ObjectIDFromHex(ownerID)
+		if err != nil {
+			return fmt.Errorf("invalid owner ID: %s", ownerID)
+		}
+		ownerIDs[i] = oid
+	}
+
+	// Check if all userIds in Owners field are valid users
+	for _, ownerID := range ownerIDs {
 		count, err := r.users.CountDocuments(context.TODO(), bson.M{"_id": ownerID})
 		if err != nil {
 			return err
 		}
 		if count == 0 {
-			return fmt.Errorf("invalid owner ID: %s", ownerID.Hex())
+			return fmt.Errorf("invalid owner ID: %s", ownerID)
 		}
 	}
 
@@ -86,36 +96,50 @@ func (r *MongoRepository) CreateSwearJar(sj swearJar.SwearJar) error {
 	return err
 }
 
-func (r *MongoRepository) GetSwearJarOwners(swearJarId primitive.ObjectID) (owners []primitive.ObjectID, err error) {
+func (r *MongoRepository) GetSwearJarOwners(swearJarId string) (owners []string, err error) {
 	type SwearJarOwners struct {
 		Owners []primitive.ObjectID `bson:"Owners"`
 	}
 
+	swearJarIdHex, err := primitive.ObjectIDFromHex(swearJarId)
 	var result SwearJarOwners
 	err = r.swearJars.FindOne(
 		context.TODO(),
-		bson.M{"_id": swearJarId},
+		bson.M{"_id": swearJarIdHex},
 		options.FindOne().SetProjection(bson.M{"Owners": 1}),
 	).Decode(&result)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
-			return nil, fmt.Errorf("invalid SwearJar ID: %s", swearJarId.Hex())
+			return nil, fmt.Errorf("invalid SwearJar ID: %s", swearJarId)
 		}
 		return nil, err
 	}
 
-	owners = result.Owners
+	for _, ownerId := range result.Owners {
+		owners = append(owners, ownerId.Hex())
+	}
+
 	return owners, nil
 }
 
 func (r *MongoRepository) AddSwear(s swearJar.Swear) error {
-	_, err := r.swears.InsertOne(
+	userIDHex, err := primitive.ObjectIDFromHex(s.UserID)
+    if err != nil {
+        return fmt.Errorf("invalid UserID: %v", err)
+    }
+
+    swearJarIdHex, err := primitive.ObjectIDFromHex(s.SwearJarId)
+    if err != nil {
+        return fmt.Errorf("invalid SwearJarId: %v", err)
+    }
+
+	_, err = r.swears.InsertOne(
 		context.TODO(),
 		bson.D{
 			{Key: "DateTime", Value: s.DateTime},
-			{Key: "UserID", Value: s.UserID},
 			{Key: "Active", Value: s.Active},
-			{Key: "SwearJarId", Value: s.SwearJarId},
+			{Key: "UserID", Value: userIDHex},
+			{Key: "SwearJarId", Value: swearJarIdHex},
 		},
 	)
 

--- a/backend/pkg/database/mongodb/types.go
+++ b/backend/pkg/database/mongodb/types.go
@@ -1,0 +1,29 @@
+package mongodb
+
+// import (
+// 	"time"
+
+// 	"go.mongodb.org/mongo-driver/bson/primitive"
+// )
+
+// type Swear struct {
+// 	ObjectID   primitive.ObjectID `bson:"_id,omitempty"`
+// 	UserID     primitive.ObjectID `bson:"user_id"`
+// 	DateTime   time.Time          `bson:"date_time"`
+// 	Active     bool               `bson:"active"`
+// 	SwearJarId primitive.ObjectID `bson:"swear_jar_id"`
+// }
+
+// type SwearJar struct {
+// 	ObjectID primitive.ObjectID   `bson:"_id,omitempty"`
+// 	Name     string               `bson:"name"`
+// 	Desc     string               `bson:"desc"`
+// 	Owners   []primitive.ObjectID `bson:"owners"`
+// }
+
+// type User struct {
+// 	ObjectID primitive.ObjectID `bson:"_id,omitempty"`
+// 	Name     string             `bson:"name"`
+// 	Password string             `bson:"password"`
+// 	Email    string             `bson:"email"`
+// }

--- a/backend/pkg/http/rest/handler.go
+++ b/backend/pkg/http/rest/handler.go
@@ -134,8 +134,8 @@ func (h *Handler) SignUp(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) CreateSwearJar(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
-		Name   string               `bson:"name"`
-		Desc   string               `bson:"desc"`
+		Name   string   `bson:"name"`
+		Desc   string   `bson:"desc"`
 		Owners []string `bson:"owners"`
 	}
 
@@ -176,9 +176,9 @@ func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s := swearJar.Swear{
-		DateTime: time.Now(),
-		Active:   true,
-		UserID:   req.UserID,
+		DateTime:   time.Now(),
+		Active:     true,
+		UserID:     req.UserID,
 		SwearJarId: req.SwearJarId,
 	}
 	err = h.sjService.AddSwear(s)

--- a/backend/pkg/http/rest/handler.go
+++ b/backend/pkg/http/rest/handler.go
@@ -166,7 +166,8 @@ func (h *Handler) CreateSwearJar(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
-		UserID primitive.ObjectID `json:"userID"`
+		UserID     primitive.ObjectID `json:"userID"`
+		SwearJarId primitive.ObjectID `json:"SwearJarId"`
 	}
 
 	var req Request
@@ -180,8 +181,8 @@ func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 		DateTime: time.Now(),
 		Active:   true,
 		UserID:   req.UserID,
+		SwearJarId: req.SwearJarId,
 	}
-
 	err = h.sjService.AddSwear(s)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/backend/pkg/http/rest/handler.go
+++ b/backend/pkg/http/rest/handler.go
@@ -5,8 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
-
 	// "os"
 	"net/http"
 	// "strconv"
@@ -138,7 +136,7 @@ func (h *Handler) CreateSwearJar(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
 		Name   string               `bson:"name"`
 		Desc   string               `bson:"desc"`
-		Owners []primitive.ObjectID `bson:"owners"`
+		Owners []string `bson:"owners"`
 	}
 
 	var req Request
@@ -166,8 +164,8 @@ func (h *Handler) CreateSwearJar(w http.ResponseWriter, r *http.Request) {
 
 func (h *Handler) AddSwear(w http.ResponseWriter, r *http.Request) {
 	type Request struct {
-		UserID     primitive.ObjectID `json:"userID"`
-		SwearJarId primitive.ObjectID `json:"SwearJarId"`
+		UserID     string `json:"userID"`
+		SwearJarId string `json:"SwearJarId"`
 	}
 
 	var req Request

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -1,11 +1,13 @@
 package swearJar
 
 type Service interface {
+	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
 	// TODO: GetSwears() []Swear
 }
 
 type Repository interface {
+	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
 	// TODO: GetSwears() []Swear
 }
@@ -17,6 +19,10 @@ type service struct {
 // NewService creates an adding service with the necessary dependencies
 func NewService(r Repository) Service {
 	return &service{r}
+}
+
+func (s *service) CreateSwearJar(sj SwearJar) error {
+	return s.r.CreateSwearJar(sj)
 }
 
 func (s *service) AddSwear(swear Swear) error {

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -2,8 +2,6 @@ package swearJar
 
 import (
 	"fmt"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Service interface {
@@ -15,7 +13,7 @@ type Service interface {
 type Repository interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
-	GetSwearJarOwners(swearJarId primitive.ObjectID) (owners []primitive.ObjectID, err error) 
+	GetSwearJarOwners(swearJarId string) (owners []string, err error) 
 	// TODO: GetSwears() []Swear
 }
 
@@ -48,7 +46,7 @@ func (s *service) AddSwear(swear Swear) error {
 		}
 	}
 	if !isOwner {
-		return fmt.Errorf("User ID: %s is not an owner of SwearJar ID: %s", swear.UserID.Hex(), swear.SwearJarId.Hex())
+		return fmt.Errorf("User ID: %s is not an owner of SwearJar ID: %s", swear.UserID, swear.SwearJarId)
 	}
 
 	return s.r.AddSwear(swear)

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -13,7 +13,7 @@ type Service interface {
 type Repository interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
-	GetSwearJarOwners(swearJarId string) (owners []string, err error) 
+	GetSwearJarOwners(swearJarId string) (owners []string, err error)
 	// TODO: GetSwears() []Swear
 }
 

--- a/backend/pkg/swearJar/service.go
+++ b/backend/pkg/swearJar/service.go
@@ -1,5 +1,11 @@
 package swearJar
 
+import (
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
+)
+
 type Service interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
@@ -9,6 +15,7 @@ type Service interface {
 type Repository interface {
 	CreateSwearJar(SwearJar) error
 	AddSwear(Swear) error
+	GetSwearJarOwners(swearJarId primitive.ObjectID) (owners []primitive.ObjectID, err error) 
 	// TODO: GetSwears() []Swear
 }
 
@@ -26,5 +33,23 @@ func (s *service) CreateSwearJar(sj SwearJar) error {
 }
 
 func (s *service) AddSwear(swear Swear) error {
+	// Fetch the owners of the SwearJar
+	owners, err := s.r.GetSwearJarOwners(swear.SwearJarId)
+	if err != nil {
+		return err
+	}
+
+	// Check if UserID is an owner of the SwearJar
+	isOwner := false
+	for _, ownerID := range owners {
+		if ownerID == swear.UserID {
+			isOwner = true
+			break
+		}
+	}
+	if !isOwner {
+		return fmt.Errorf("User ID: %s is not an owner of SwearJar ID: %s", swear.UserID.Hex(), swear.SwearJarId.Hex())
+	}
+
 	return s.r.AddSwear(swear)
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -2,14 +2,11 @@ package swearJar
 
 import (
 	"time"
-
-	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Swear struct {
-	ObjectID   primitive.ObjectID `bson:"_id,omitempty"`
-	UserID     primitive.ObjectID `bson:"user_id"`
-	DateTime   time.Time          `bson:"swear_time"`
+	UserID     string `bson:"user_id"`
+	DateTime   time.Time          `bson:"date_time"`
 	Active     bool               `bson:"active"`
-	SwearJarId primitive.ObjectID `bson:"swear_jar_id"`
+	SwearJarId string `bson:"swear_jar_id"`
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Swear struct {
-	UserID     string `bson:"user_id"`
-	DateTime   time.Time          `bson:"date_time"`
-	Active     bool               `bson:"active"`
-	SwearJarId string `bson:"swear_jar_id"`
+	UserID     string
+	DateTime   time.Time
+	Active     bool
+	SwearJarId string
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -11,5 +11,5 @@ type Swear struct {
 	UserID     primitive.ObjectID `bson:"user_id"`
 	DateTime   time.Time          `bson:"swear_time"`
 	Active     bool               `bson:"active"`
-	swearJarId primitive.ObjectID `bson:"swear_jar_id"`
+	SwearJarId primitive.ObjectID `bson:"swear_jar_id"`
 }

--- a/backend/pkg/swearJar/swear.go
+++ b/backend/pkg/swearJar/swear.go
@@ -1,13 +1,15 @@
 package swearJar
 
 import (
-	"go.mongodb.org/mongo-driver/bson/primitive"
 	"time"
+
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 type Swear struct {
-	ObjectID primitive.ObjectID `bson:"_id,omitempty"`
-	UserID   primitive.ObjectID `bson:"user_id"`
-	DateTime time.Time          `bson:"swear_time"`
-	Active   bool               `bson:"active"`
+	ObjectID   primitive.ObjectID `bson:"_id,omitempty"`
+	UserID     primitive.ObjectID `bson:"user_id"`
+	DateTime   time.Time          `bson:"swear_time"`
+	Active     bool               `bson:"active"`
+	swearJarId primitive.ObjectID `bson:"swear_jar_id"`
 }

--- a/backend/pkg/swearJar/swearJar.go
+++ b/backend/pkg/swearJar/swearJar.go
@@ -1,10 +1,8 @@
 package swearJar
 
-import "go.mongodb.org/mongo-driver/bson/primitive"
-
 type SwearJar struct {
-	ObjectID primitive.ObjectID   `bson:"_id,omitempty"`
-	Name     string               `bson:"name"`
-	Desc     string               `bson:"desc"`
-	Owners   []primitive.ObjectID `bson:"owners"`
+	ID     string   `json:"id"`
+	Name   string   `json:"name"`
+	Desc   string   `json:"desc"`
+	Owners []string `json:"owners"`
 }

--- a/backend/pkg/swearJar/swearJar.go
+++ b/backend/pkg/swearJar/swearJar.go
@@ -1,0 +1,10 @@
+package swearJar
+
+import "go.mongodb.org/mongo-driver/bson/primitive"
+
+type SwearJar struct {
+	ObjectID primitive.ObjectID   `bson:"_id,omitempty"`
+	Name     string               `bson:"name"`
+	Desc     string               `bson:"desc"`
+	Owners   []primitive.ObjectID `bson:"owners"`
+}

--- a/backend/pkg/swearJar/swearJar.go
+++ b/backend/pkg/swearJar/swearJar.go
@@ -1,8 +1,8 @@
 package swearJar
 
 type SwearJar struct {
-	ID     string   `json:"id"`
-	Name   string   `json:"name"`
-	Desc   string   `json:"desc"`
-	Owners []string `json:"owners"`
+	ID     string
+	Name   string
+	Desc   string
+	Owners []string
 }


### PR DESCRIPTION
### Description:
This pull request separates the Service and Repository layers by removing the use of mongoDB's primitive package in rest, swearJar and authentication packages.